### PR TITLE
バッファサイズの修正とライティング設定の追加

### DIFF
--- a/gameEngine/3d/Model.cpp
+++ b/gameEngine/3d/Model.cpp
@@ -71,7 +71,7 @@ void Model::VertexResource()
 void Model::MaterialResource()
 {
     // --- materialResourceの作成 ---
-    materialResource = modelCommon_->GetDxCommon()->CreateBufferResource(sizeof(Material)*2);
+    materialResource = modelCommon_->GetDxCommon()->CreateBufferResource(sizeof(Material));
 
     // --- materialDataに割り当てる ---
     materialResource->Map(0, nullptr, reinterpret_cast<void**>(&materialData));

--- a/gameEngine/3d/Model.h
+++ b/gameEngine/3d/Model.h
@@ -28,6 +28,9 @@ public:
 	// モデルデータの読み込み
 	void ModelUpload();
 
+    // モデルデータの読み込み
+	void SetEnableLighting(bool _flag) { materialData->enableLighting = _flag; }
+
 private:
 	// ===== 構造体 =====
 	// --- 頂点データ ---

--- a/gameEngine/3d/Object3d.h
+++ b/gameEngine/3d/Object3d.h
@@ -6,6 +6,7 @@
 #include <wrl.h>
 
 #include "Camera.h"
+#include "Model.h"
 
 #include "Vector2.h"
 #include "Vector3.h"
@@ -13,7 +14,6 @@
 #include "Matrix4x4.h"
 
 class Object3dCommon;
-class Model;
 
 // 3Dオブジェクト
 class Object3d
@@ -46,6 +46,9 @@ public:
 
 	// camera
 	void SetCamera(Camera* camera) { this->camera = camera; }
+
+	// lighting
+	void SetEnableLighting(bool _flag) { model->SetEnableLighting(_flag); }
 
 private:
 	//Data書き込み


### PR DESCRIPTION
`Model.cpp`の`MaterialResource`メソッドでバッファサイズを`sizeof(Material)*2`から`sizeof(Material)`に変更しました。 `Model.h`に`SetEnableLighting`メソッドを追加し、`materialData`の`enableLighting`フラグを設定できるようにしました。 `Object3d.h`で`Model`クラスのインクルードを追加し、前方宣言`class Model;`を削除しました。 `Object3d.h`に`SetEnableLighting`メソッドを追加し、`model`オブジェクトの`SetEnableLighting`メソッドを呼び出すようにしました。